### PR TITLE
Added nullcheck as pod IP might be null. Upgraded activemq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <activemq.version>5.14.4</activemq.version>
+    <activemq.version>5.14.5</activemq.version>
     <kubernetes-client.version>2.2.13</kubernetes-client.version>
     <junit.version>4.12</junit.version>
     <slf4j.version>1.7.25</slf4j.version>

--- a/src/main/java/org/apache/activemq/transport/discovery/k8s/KubernetesDiscoveryAgent.java
+++ b/src/main/java/org/apache/activemq/transport/discovery/k8s/KubernetesDiscoveryAgent.java
@@ -16,14 +16,8 @@
  */
 package org.apache.activemq.transport.discovery.k8s;
 
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.activemq.command.DiscoveryEvent;
 import org.apache.activemq.thread.TaskRunnerFactory;
 import org.apache.activemq.transport.discovery.DiscoveryAgent;
@@ -31,8 +25,14 @@ import org.apache.activemq.transport.discovery.DiscoveryListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 /**
  * The KubernetDiscoveryAgent can be used to build a network of brokers with

--- a/src/main/java/org/apache/activemq/transport/discovery/k8s/KubernetesDiscoveryAgent.java
+++ b/src/main/java/org/apache/activemq/transport/discovery/k8s/KubernetesDiscoveryAgent.java
@@ -93,7 +93,7 @@ public class KubernetesDiscoveryAgent implements DiscoveryAgent {
             return "[" + serviceName + ", failed:" + failed + ", connectionFailures:" + connectFailures + "]";
         }
     }
-    
+
     private class KubernetesPodEnumerator implements Runnable {
         @Override
         public void run() {
@@ -104,7 +104,9 @@ public class KubernetesDiscoveryAgent implements DiscoveryAgent {
                     final Set<String> availableServices = client.pods().inNamespace(namespace)
                         .withLabel(podLabelKey, podLabelValue)
                         .list().getItems().stream()
-                        .map(pod -> String.format(serviceUrlFormat, pod.getStatus().getPodIP()))
+                        .map(pod -> pod.getStatus().getPodIP())
+                        .filter(Objects::nonNull)
+                        .map( ip -> String.format(serviceUrlFormat, ip))
                         .collect(Collectors.toSet());
 
                     // Determine the list of service we need to add


### PR DESCRIPTION
Turns out that `pod.getStatus().getPodIP()` might return null on a k8s gcp cluster. 

Also upgraded activemq dependency from 5.14.4 to  5.14.5.

Useful to know: I needed to add `maxReconnectAttempts=3` as killed pod would get a new ip in my setup. It (seems to) get the same ip in Minikube.