### PR TITLE
Solving reconnect problem by checking pod status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,25 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-/target/
 
-.classpath
+dependency-reduced-pom.xml
+target/
+.idea
+*.iml
+.gradle
+.vertx
+build/
+    
+#Eclipse files
 .project
 .settings
+.classpath
+.metadata
+
+#Backup files
+*~
+lib/
+gradle/
+gradlew
+gradlew.bat
+    

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <activemq.version>5.14.5</activemq.version>
-    <kubernetes-client.version>2.2.13</kubernetes-client.version>
+    <kubernetes-client.version>2.6.3</kubernetes-client.version>
     <junit.version>4.12</junit.version>
     <slf4j.version>1.7.25</slf4j.version>
   </properties>

--- a/src/main/java/org/apache/activemq/transport/discovery/k8s/KubernetesDiscoveryAgent.java
+++ b/src/main/java/org/apache/activemq/transport/discovery/k8s/KubernetesDiscoveryAgent.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.transport.discovery.k8s;
 
+import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.activemq.command.DiscoveryEvent;
@@ -29,6 +30,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -104,6 +106,7 @@ public class KubernetesDiscoveryAgent implements DiscoveryAgent {
                     final Set<String> availableServices = client.pods().inNamespace(namespace)
                         .withLabel(podLabelKey, podLabelValue)
                         .list().getItems().stream()
+                        .filter( pod -> allConditionsOk( pod.getStatus().getConditions()))
                         .map(pod -> pod.getStatus().getPodIP())
                         .filter(Objects::nonNull)
                         .map( ip -> String.format(serviceUrlFormat, ip))
@@ -150,6 +153,34 @@ public class KubernetesDiscoveryAgent implements DiscoveryAgent {
                 }
             }
         }
+
+        private boolean allConditionsOk(List<PodCondition> conditions) {
+            Optional<PodCondition> notRunning = conditions
+                    .stream()
+                    .filter( c -> !isConditionOk( c))
+                    .findFirst();
+            return ! notRunning.isPresent();
+        }
+
+        private boolean isConditionOk(PodCondition c) {
+            switch ( c.getType()) {
+                case "OutOfDisk":
+                case "NetworkUnavailable":
+                    return !c.getStatus().equals("True");
+                case "MemoryPressure":
+                case "DiskPressure":
+                case "PodScheduled":
+                case "Initialized":
+                    return true;
+                case "Ready":
+                    return c.getStatus().equals("True");
+                default:
+                    LOG.warn("Do not know what to make of status "+c.getType()+", just returning true.");
+                    return  true;
+            }
+        }
+
+
     }
 
     @Override


### PR DESCRIPTION
Code would previously check only if pod had got an IP in order to deem it live. This turns out not to be enough, and we got problems with pods not reconnecting after outage.

Now checking on pod ready state and container state in order to remove pods which are not ready at a given moment.